### PR TITLE
Set latency_timer in udev rules to reduce communication latency

### DIFF
--- a/udev/80-e151.rules
+++ b/udev/80-e151.rules
@@ -3,3 +3,8 @@ SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ATTRS{produ
 SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ATTRS{product}=="RIGHT-E151", ENV{ID_USB_INTERFACE_NUM}=="00", GROUP="dialout", MODE="0666", SYMLINK+="rhand-e151"
 SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ATTRS{product}=="LEFT-V2-E151", ENV{ID_USB_INTERFACE_NUM}=="00", GROUP="dialout", MODE="0666", SYMLINK+="lhand-v2-e151"
 SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ATTRS{product}=="RIGHT-V2-E151", ENV{ID_USB_INTERFACE_NUM}=="00", GROUP="dialout", MODE="0666", SYMLINK+="rhand-v2-e151"
+# Set latency_timer to reduce communication latency
+SUBSYSTEM=="usb-serial", DRIVER=="ftdi_sio", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ATTRS{product}=="LEFT-E151", ENV{ID_USB_INTERFACE_NUM}=="00", ATTR{latency_timer}="1"
+SUBSYSTEM=="usb-serial", DRIVER=="ftdi_sio", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ATTRS{product}=="RIGHT-E151", ENV{ID_USB_INTERFACE_NUM}=="00", ATTR{latency_timer}="1"
+SUBSYSTEM=="usb-serial", DRIVER=="ftdi_sio", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ATTRS{product}=="LEFT-V2-E151", ENV{ID_USB_INTERFACE_NUM}=="00", ATTR{latency_timer}="1"
+SUBSYSTEM=="usb-serial", DRIVER=="ftdi_sio", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ATTRS{product}=="RIGHT-V2-E151", ENV{ID_USB_INTERFACE_NUM}=="00", ATTR{latency_timer}="1"

--- a/udev/80-ft2232c.rules
+++ b/udev/80-ft2232c.rules
@@ -1,3 +1,5 @@
 # Create symlink /dev/{r/l}hand-ft2232c
 SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", ENV{ID_USB_INTERFACE_NUM}=="00", GROUP="dialout", MODE="0666", SYMLINK+="rhand-ft2232c"
 # SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", ATTR{bInterfaceNumber}=="00", GROUP="dialout", MODE="0666", SYMLINK+="lhand-ft2232c"
+# Set latency_timer to reduce communication latency
+SUBSYSTEM=="usb-serial", DRIVER=="ftdi_sio", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", ENV{ID_USB_INTERFACE_NUM}=="00", ATTR{latency_timer}="1"


### PR DESCRIPTION
This may prevent DroppedPacketError in `roslaunch softhand_ros softhand_v2_right.launch`.
See https://github.com/ros-drivers/rosserial/issues/383 for latency problem & its solution.
See https://projectgus.com/2011/10/notes-on-ftdi-latency-with-arduino/ for detailed info about latency_timer.

To test this PR, you have to re-execute https://github.com/knorth55/softhand_ros#udev-installation.
Perhaps rebooting PC will be required.